### PR TITLE
update readme with required version of cucumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Once official support is established, this package will be abandoned.
 
 Install `gherkin-testcafe` and `cucumber`<sup>1</sup> via npm or yarn:
 
-    npm i gherkin-testcafe cucumber
+    npm i gherkin-testcafe cucumber@5.1.0
 
 or
 
-    yarn add gherkin-testcafe cucumber
+    yarn add gherkin-testcafe cucumber@5.1.0
 
 <sup>1</sup> This package internally uses [Cucumber.js](https://github.com/cucumber/cucumber-js) to parse step definitions.
-You will need it to define steps (see [Writing step definitions](#writing-step-definitions)).
+You will need it to define steps (see [Writing step definitions](#writing-step-definitions)). Only cucumber version 5.1.0 is supported.
 
 ## Upgrading from version 1.x
 


### PR DESCRIPTION
encountered some small issues when installing gherkin-testcafe and cucumber in the way the readme describes. Fixed when specifying the cucumber version to be 5.1.0