### PR TITLE
chore(examples): add an example of docstring usage

### DIFF
--- a/examples/custom-param-type.js
+++ b/examples/custom-param-type.js
@@ -7,7 +7,7 @@ const Selector = (input, t) => {
 
 When('I am searching for the {color} color on Google', async (t, [color]) => {
   const input = Selector('[name="q"]', t);
-  await t.typeText(input, color.name);
+  await t.typeText(input, `${color.name} code`);
 });
 
 Then('I should see the {word} value in the page', async (t, [value]) => {

--- a/examples/doc-strings.feature
+++ b/examples/doc-strings.feature
@@ -1,0 +1,12 @@
+Feature: Doc string feature
+
+    I want to use a doc string in my test
+
+    Scenario: Asserting page subtitle
+        Given I opened TestCafe demo page
+        Then I should see the following page subtitle
+            """
+            This webpage is used as a sample in TestCafe tutorials.
+            """
+
+# this only works for v5.0.0 or above

--- a/examples/doc-strings.ts
+++ b/examples/doc-strings.ts
@@ -1,0 +1,10 @@
+import { Given, Then } from '@cucumber/cucumber';
+import { Selector } from 'testcafe';
+
+Given('I opened TestCafe demo page', async (t) => {
+  await t.navigateTo('https://devexpress.github.io/testcafe/example/');
+});
+
+Then('I should see the following page subtitle', async (t, [], _, docString) => {
+  await t.expect(Selector('header > p').textContent).contains(docString);
+});

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prettier": "prettier --write 'src/**/*.js' README.md main.js index.d.ts",
     "prettier-check": "prettier --list-different 'src/**/*.{js,yaml,yml,json,md}'",
     "google-example": "node main.js chrome examples/google.ts ./examples/google.feature",
+    "docstring-example": "node main.js chrome examples/doc-strings.*",
     "datatable-example": "node main.js chrome ./examples/datatable.js ./examples/datatable.feature",
     "custom-param-type-example": "node main.js chrome examples/google.ts ./examples/custom-param-type.js ./examples/custom-param-type.feature --param-type-registry-file ./examples/custom-param-type-registry.js",
     "gitcommit": "git-cz",


### PR DESCRIPTION
shows how to use docstrings, also fixes the custom param example

re #64