### PR TITLE
feat(globalhooks): add the ability to access features metadata

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,9 +24,13 @@ declare module 'gherkin-testcafe' {
     }
 
     interface GherkinTestCafeFactory extends TestCafeFactory {
-      (hostname?: string, port1?: number, port2?: number, sslOptions?: TlsOptions, developmentMode?: boolean): Promise<
-        GherkinTestCafe
-      >;
+      (
+        hostname?: string,
+        port1?: number,
+        port2?: number,
+        sslOptions?: TlsOptions,
+        developmentMode?: boolean
+      ): Promise<GherkinTestCafe>;
     }
   }
 
@@ -57,7 +61,10 @@ declare module '@cucumber/cucumber' {
   }
 
   export type HookFunction = (testController: typeof t) => Promise<void>;
-  export type GlobalHookFunction = (fixtureContext: { [key: string]: any }) => Promise<void>;
+  export type GlobalHookFunction = (
+    fixtureContext: { [key: string]: any },
+    fixtureMeta: Record<string, string>
+  ) => Promise<void>;
 
   export function After(code: HookFunction): void;
   export function After(options: string, code: HookFunction): void;


### PR DESCRIPTION
A global hook (BeforeAll and AfterAll) will run before or after every
single feature.
However they could only be used to add information to the context (which
is empty when the feature starts).
No information about the feature could be used in the hooks. The global
hooks are now capable of passing a copy of the metadata (name of the
feature and tags, at the moment) to the hook function, allowing for more
targeted behaviors.