### PR TITLE
use inclusive range on testcafe peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "peerDependencies": {
     "@cucumber/cucumber": "^9.1.0",
     "@cucumber/cucumber-expressions": "^16.0.0",
-    "testcafe": "^2.0.0 <= 3.2.0"
+    "testcafe": "2.0.0 - 3.2.0"
   },
   "devDependencies": {
     "@cucumber/cucumber": "9.4.0",


### PR DESCRIPTION
Previous term has been excluding all 3.x releases of TestCafe according to https://semver.npmjs.com/. This one is inclusively enabling all 2.x release and 3.x releases up to and including 3.2.0.

related to #139 